### PR TITLE
[DEVOPS-364] Remove unused glob

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -694,10 +694,6 @@ boost_library(
 
 boost_library(
     name = "coroutine2",
-    hdrs = glob([
-        "libs/coroutine2/include/**/*.hpp",
-        "libs/coroutine2/include/**/*.ipp",
-    ]),
     deps = [
         ":assert",
         ":config",
@@ -2108,7 +2104,7 @@ boost_library(
 boost_library(
     name = "unordered",
     srcs = glob([
-        "boost/unordered_map/**/*.hpp",
+        "boost/unordered/**/*.hpp",
     ]),
     hdrs = [
         "boost/unordered_map.hpp",


### PR DESCRIPTION
Changelog
===

Remove unused glob so that `--incompatible_disallow_empty_glob` Bazel flag can be applied in pennybot repo.


Testing
===

Run `bazel test //...` in pennybot